### PR TITLE
Enable BFloat16 Automatic Mixed Precision (AMP) in TensorFlow Serving

### DIFF
--- a/tensorflow_serving/g3doc/serving_config.md
+++ b/tensorflow_serving/g3doc/serving_config.md
@@ -285,3 +285,4 @@ notable ones. For a complete list, please refer to the
     model_base_path
 *   `--enable_model_warmup`: Enables [model warmup](saved_model_warmup.md) using
     user-provided PredictionLogs in assets.extra/ directory
+*   `--mixed_precision=bfloat16`: Enables BF16 AUtomatic Mixed Precision

--- a/tensorflow_serving/g3doc/serving_config.md
+++ b/tensorflow_serving/g3doc/serving_config.md
@@ -285,4 +285,4 @@ notable ones. For a complete list, please refer to the
     model_base_path
 *   `--enable_model_warmup`: Enables [model warmup](saved_model_warmup.md) using
     user-provided PredictionLogs in assets.extra/ directory
-*   `--mixed_precision=bfloat16`: Enables BF16 AUtomatic Mixed Precision
+*   `--mixed_precision=bfloat16`: Enables BF16 Automatic Mixed Precision

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -290,7 +290,9 @@ int main(int argc, char** argv) {
       tensorflow::Flag("thread_pool_factory_config_file",
                        &options.thread_pool_factory_config_file,
                        "If non-empty, read an ascii ThreadPoolConfig protobuf "
-                       "from the supplied file name.")};
+                       "from the supplied file name."),
+      tensorflow::Flag("mixed_precision", &options.mixed_precision,
+                      "specify mixed_precision mode")};
 
   const auto& usage = tensorflow::Flags::Usage(argv[0], flag_list);
   if (!tensorflow::Flags::Parse(&argc, argv, flag_list)) {

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -288,6 +288,7 @@ Status Server::BuildAndStart(const Options& server_options) {
     session_bundle_config.set_num_tflite_interpreters_per_pool(
         server_options.num_tflite_interpreters_per_pool);
     session_bundle_config.set_num_tflite_pools(server_options.num_tflite_pools);
+    session_bundle_config.set_mixed_precision(server_options.mixed_precision);
 
     TF_RETURN_IF_ERROR(
         tensorflow::serving::init::SetupPlatformConfigMapForTensorFlow(

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -101,6 +101,7 @@ class Server {
     tensorflow::string thread_pool_factory_config_file;
     bool enable_signature_method_name_check = false;
     bool enable_profiler = true;
+    tensorflow::string mixed_precision;
 
     Options();
   };

--- a/tensorflow_serving/servables/tensorflow/saved_model_bundle_factory.cc
+++ b/tensorflow_serving/servables/tensorflow/saved_model_bundle_factory.cc
@@ -130,7 +130,9 @@ Status SavedModelBundleFactory::InternalCreateSavedModelBundle(
         RewriterConfig* rwcfg = gopt->mutable_rewrite_options();
         rwcfg->set_auto_mixed_precision_onednn_bfloat16(RewriterConfig::ON);
       } else {
-        LOG(WARNING) << config_.mixed_precision() << " auto mixed precision is not supported. Valid option: bfloat16";
+        LOG(WARNING) 
+            << config_.mixed_precision() 
+            << " auto mixed precision is not supported. Valid option: bfloat16";
       }
     }
     if (metadata.has_value()) {

--- a/tensorflow_serving/servables/tensorflow/session_bundle_config.proto
+++ b/tensorflow_serving/servables/tensorflow/session_bundle_config.proto
@@ -134,6 +134,9 @@ message SessionBundleConfig {
   //
   // Enable overriding model configs via assets.extra/saved_model_config.pb.
   bool enable_saved_model_config = 790;
+
+  //Add bf16 mixed_precision option
+  string mixed_precision = 791;
 }
 
 // Batching parameters. Each individual parameter is optional. If omitted, the


### PR DESCRIPTION
This PR allows users to enable BFloat16 AMP by adding `--mixed_precision=bfloat16` flag when starting the model server. 

AMP can accelerate inference significantly. We observed different degrees of speedup for TensorFlow Hub detection models. For example: [faster_rcnn/inception_resnet_v2_1024x1024 ](https://tfhub.dev/tensorflow/faster_rcnn/inception_resnet_v2_1024x1024/1) can achieve ~1.4X speedup when BFloat16 AMP is enabled, compared to running inference with the FP32 model.